### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The settings intended to be configured with gin are:
 - `RLSettings` (`aprl_defense.trial.settings.RLSettings`)
 - Additionally, depending on whether one of these modes is used
     - `selfplay` (`aprl_defense.training_managers.simple_training_manager.SelfplayTrainingManager`)
-    - `single-agent` - no additonal arguments
+    - `single-agent` - no additional arguments
     - `attack` (`aprl_defense.training_managers.simple_training_manager.AttackManager`)
     - `pbt` (`aprl_defense.training_managers.pbt_manager.PBTManager`)
   


### PR DESCRIPTION
## Summary
- fix a typo in README about single-agent mode

## Testing
- `pre-commit` *(skipped: documentation only)*