### PR TITLE
Fix Ray requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ torch==1.10.0
 # We use a version of ray that includes modifications. By installing the wheel which corresponds to the master branch at the time of making
 # this change, we don't need to build the binary parts of ray from source ourselves. Instead, ray includes a script that combines the binary
 # parts from the wheel with our modified python code.
-ray[rllib,default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/master/6441335f5e8447ad07c0dbb7916e11aa43591876/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+ray[rllib]==2.0.0
 prometheus_client==0.13.1  # default version with ray-2.0.0 is broken
 
 # Ray 1.10


### PR DESCRIPTION
## Summary
- update Ray requirement to official release in `requirements.txt`

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: could not find a matching distribution)*
- `pytest -q` *(fails: command not found)*